### PR TITLE
Add Experience page and responsive navbar tweaks

### DIFF
--- a/src/Components/Experience.jsx
+++ b/src/Components/Experience.jsx
@@ -1,0 +1,362 @@
+/* eslint-disable react/no-unknown-property */
+import { motion } from "framer-motion";
+import { useTheme } from "./ThemeContext";
+import {
+  FiBriefcase,
+  FiMapPin,
+  FiCalendar,
+  FiArrowRight,
+  FiCpu,
+  FiUsers,
+} from "react-icons/fi";
+import { FaNodeJs } from "react-icons/fa";
+import { SiExpress, SiFirebase, SiGooglecloud } from "react-icons/si";
+
+const EXPERIENCE = {
+  role: "Backend Engineer Intern",
+  company: "Primordial Intelligence Pvt. Ltd. (Backed by RTIH)",
+  period: "Nov 2025 – Jan 2026 | Remote",
+  location: "Remote",
+  product:
+    "Campus AI-Aided Institutional Management System",
+  overview:
+    "Worked as a Backend Engineer Intern on a Campus AI-Aided Institutional Management System, contributing to the design, development, and optimization of scalable backend services. Collaborated closely with frontend and AI teams to support intelligent, data-driven academic workflows.",
+  contributions: [
+    "Developed and maintained scalable backend services using Node.js and Express.js to support core institutional operations and academic workflows.",
+    "Designed and implemented RESTful APIs for modules such as user onboarding, authentication, student/faculty/administrator management, and academic workflows.",
+    "Integrated Firebase Authentication for secure user login and identity management, and Firestore for real-time data storage and synchronization.",
+    "Implemented Role-Based Access Control (RBAC) to enforce fine-grained permissions for students, faculty, and administrators.",
+    "Optimized backend logic and database interactions to reduce API response times and improve data consistency across services.",
+    "Collaborated with frontend developers to ensure smooth API integration and reliable data flow between client and server.",
+    "Worked with AI/ML teams to connect backend services with AI-driven insights and automation features.",
+    "Followed clean architecture principles and MVC design patterns to keep the codebase modular, maintainable, and production-ready.",
+  ],
+  techStack: [
+    { name: "Node.js", icon: <FaNodeJs className="text-green-500" /> },
+    { name: "Express.js", icon: <SiExpress className="text-gray-300" /> },
+    { name: "Firebase Authentication", icon: <SiFirebase className="text-yellow-400" /> },
+    { name: "Firestore", icon: <SiGooglecloud className="text-blue-500" /> },
+    { name: "REST APIs", icon: <FiCpu className="text-cyan-400" /> },
+    { name: "RBAC", icon: <FiUsers className="text-purple-400" /> },
+    { name: "MVC Architecture", icon: <FiBriefcase className="text-emerald-400" /> },
+  ],
+  impact:
+    "This internship strengthened my experience in building secure, scalable backend systems and collaborating across frontend and AI teams in a real-world production environment.",
+};
+
+// Animation variants
+const container = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.15,
+      delayChildren: 0.2,
+    },
+  },
+};
+
+const cardItem = {
+  hidden: { opacity: 0, y: 24 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      type: "spring",
+      stiffness: 120,
+      damping: 16,
+    },
+  },
+};
+
+const fadeIn = {
+  hidden: { opacity: 0, y: -20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.6,
+      ease: "easeOut",
+    },
+  },
+};
+
+export default function Experience() {
+  const { darkMode } = useTheme();
+
+  return (
+    <div
+      className={`min-h-screen py-12 px-4 sm:px-6 lg:px-8 ${
+        darkMode ? "bg-[#020617] text-gray-100" : "bg-slate-50 text-slate-900"
+      }`}
+    >
+      <div className="max-w-6xl mx-auto">
+        {/* Header */}
+        <motion.div
+          initial="hidden"
+          animate="visible"
+          variants={fadeIn}
+          className="text-center mb-12"
+        >
+          <div
+            className={`inline-flex items-center px-4 py-1.5 rounded-full mb-4 text-xs sm:text-sm font-medium ${
+              darkMode
+                ? "bg-gray-800 text-cyan-300 border border-cyan-500/40"
+                : "bg-white text-cyan-700 border border-cyan-300/60"
+            } shadow-sm`}
+          >
+            <FiBriefcase className="mr-2" />
+            Internship Experience
+          </div>
+          <h1
+            className={`text-3xl md:text-4xl lg:text-5xl font-bold mb-3 ${
+              darkMode ? "text-white" : "text-gray-900"
+            }`}
+          >
+            Backend Engineer{" "}
+            <span
+              className={
+                darkMode
+                  ? "text-yellow-300"
+                  : "text-yellow-600"
+              }
+            >
+              Internship
+            </span>
+          </h1>
+          <p
+            className={`text-sm sm:text-base max-w-2xl mx-auto ${
+              darkMode ? "text-gray-300" : "text-gray-600"
+            }`}
+          >
+            Campus AI-Aided Institutional Management System &mdash; building
+            secure, scalable backend services for data-driven academic
+            workflows.
+          </p>
+        </motion.div>
+
+        {/* Top summary card */}
+        <motion.div
+          variants={cardItem}
+          initial="hidden"
+          animate="visible"
+          className={`mb-10 p-6 sm:p-8 rounded-2xl shadow-xl border ${
+            darkMode
+              ? "bg-gray-900/70 border-gray-700/60"
+              : "bg-white border-gray-200/80"
+          }`}
+        >
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <h2
+                className={`text-xl sm:text-2xl font-semibold ${
+                  darkMode ? "text-white" : "text-gray-900"
+                }`}
+              >
+                {EXPERIENCE.role}
+              </h2>
+              <p
+                className={`mt-1 text-sm sm:text-base font-medium ${
+                  darkMode ? "text-cyan-300" : "text-cyan-700"
+                }`}
+              >
+                {EXPERIENCE.company}
+              </p>
+            </div>
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 text-sm">
+              <div
+                className={`inline-flex items-center px-3 py-1 rounded-full ${
+                  darkMode
+                    ? "bg-gray-800 text-gray-200"
+                    : "bg-gray-100 text-gray-700"
+                }`}
+              >
+                <FiCalendar className="mr-1.5" />
+                {EXPERIENCE.period}
+              </div>
+              <div
+                className={`inline-flex items-center px-3 py-1 rounded-full ${
+                  darkMode
+                    ? "bg-gray-800 text-gray-200"
+                    : "bg-gray-100 text-gray-700"
+                }`}
+              >
+                <FiMapPin className="mr-1.5" />
+                {EXPERIENCE.location}
+              </div>
+            </div>
+          </div>
+          <p
+            className={`mt-4 text-sm sm:text-base leading-relaxed ${
+              darkMode ? "text-gray-300" : "text-gray-700"
+            }`}
+          >
+            {EXPERIENCE.overview}
+          </p>
+        </motion.div>
+
+        {/* Main grid */}
+        <motion.div
+          variants={container}
+          initial="hidden"
+          animate="visible"
+          className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8"
+        >
+          {/* Key Contributions */}
+          <motion.div
+            variants={cardItem}
+            className={`lg:col-span-2 p-6 sm:p-7 rounded-2xl shadow-lg border ${
+              darkMode
+                ? "bg-gray-900/80 border-gray-700/60"
+                : "bg-white border-gray-200/80"
+            }`}
+          >
+            <div className="flex items-center mb-4">
+              <div
+                className={`p-2.5 rounded-xl mr-3 ${
+                  darkMode ? "bg-gray-800" : "bg-gray-100"
+                }`}
+              >
+                <FiArrowRight
+                  className={
+                    darkMode ? "text-yellow-300" : "text-yellow-600"
+                  }
+                />
+              </div>
+              <div>
+                <h3
+                  className={`text-lg sm:text-xl font-semibold ${
+                    darkMode ? "text-white" : "text-gray-900"
+                  }`}
+                >
+                  Key Contributions &amp; Responsibilities
+                </h3>
+                <p
+                  className={`text-xs sm:text-sm ${
+                    darkMode ? "text-gray-400" : "text-gray-500"
+                  }`}
+                >
+                  Hands-on ownership across API design, security, and
+                  performance.
+                </p>
+              </div>
+            </div>
+            <ul className="space-y-3 text-sm sm:text-base">
+              {EXPERIENCE.contributions.map((item, idx) => (
+                <motion.li
+                  key={idx}
+                  variants={cardItem}
+                  className="flex items-start"
+                >
+                  <span
+                    className={`mt-1 mr-3 inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-xs ${
+                      darkMode
+                        ? "bg-yellow-500/10 text-yellow-300 border border-yellow-400/40"
+                        : "bg-yellow-100 text-yellow-700 border border-yellow-300/80"
+                    }`}
+                  >
+                    ●
+                  </span>
+                  <span
+                    className={
+                      darkMode ? "text-gray-300" : "text-gray-700"
+                    }
+                  >
+                    {item}
+                  </span>
+                </motion.li>
+              ))}
+            </ul>
+          </motion.div>
+
+          {/* Tech & Impact */}
+          <div className="space-y-6">
+            {/* Tech Stack */}
+            <motion.div
+              variants={cardItem}
+              className={`p-5 sm:p-6 rounded-2xl shadow-lg border ${
+                darkMode
+                  ? "bg-gray-900/80 border-gray-700/60"
+                  : "bg-white border-gray-200/80"
+              }`}
+            >
+              <div className="flex items-center mb-4">
+                <div
+                  className={`p-2.5 rounded-xl mr-3 ${
+                    darkMode ? "bg-gray-800" : "bg-gray-100"
+                  }`}
+                >
+                  <FiCpu
+                    className={
+                      darkMode ? "text-cyan-300" : "text-cyan-600"
+                    }
+                  />
+                </div>
+                <div>
+                  <h3
+                    className={`text-lg font-semibold ${
+                      darkMode ? "text-white" : "text-gray-900"
+                    }`}
+                  >
+                    Tech Stack
+                  </h3>
+                  <p
+                    className={`text-xs sm:text-sm ${
+                      darkMode ? "text-gray-400" : "text-gray-500"
+                    }`}
+                  >
+                    Tools and technologies used throughout the internship.
+                  </p>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {EXPERIENCE.techStack.map((tech, idx) => (
+                  <motion.div
+                    key={tech.name}
+                    whileHover={{ y: -2, scale: 1.03 }}
+                    transition={{ type: "spring", stiffness: 250, damping: 18 }}
+                    className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs sm:text-sm ${
+                      darkMode
+                        ? "bg-gray-800 text-gray-200 border border-gray-700"
+                        : "bg-gray-100 text-gray-700 border border-gray-200"
+                    }`}
+                  >
+                    <span className="mr-2 text-base">{tech.icon}</span>
+                    <span>{tech.name}</span>
+                  </motion.div>
+                ))}
+              </div>
+            </motion.div>
+
+            {/* Impact */}
+            <motion.div
+              variants={cardItem}
+              className={`p-5 sm:p-6 rounded-2xl shadow-lg border ${
+                darkMode
+                  ? "bg-gradient-to-br from-emerald-900/70 via-gray-900/80 to-cyan-900/60 border-emerald-600/60"
+                  : "bg-gradient-to-br from-emerald-50 via-white to-cyan-50 border-emerald-200"
+              }`}
+            >
+              <h3
+                className={`text-lg font-semibold mb-2 ${
+                  darkMode ? "text-emerald-200" : "text-emerald-700"
+                }`}
+              >
+                Impact & Learnings
+              </h3>
+              <p
+                className={`text-sm sm:text-base leading-relaxed ${
+                  darkMode ? "text-emerald-50" : "text-emerald-800"
+                }`}
+              >
+                {EXPERIENCE.impact}
+              </p>
+            </motion.div>
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}
+
+

--- a/src/Components/MainNavBar.jsx
+++ b/src/Components/MainNavBar.jsx
@@ -1,13 +1,16 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable react/prop-types */
 /* eslint-disable react/no-unknown-property */
+import React from 'react';
 import { useState, useEffect } from 'react';
 import { Route, Routes, NavLink } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
-import { FiHome, FiUser, FiBook, FiCode, FiLayers, FiMail, FiSun, FiMoon, FiGithub, FiLinkedin, FiX } from 'react-icons/fi';
+import { FiHome, FiUser, FiBook, FiCode, FiLayers, FiMail, FiSun, FiMoon, FiGithub, FiLinkedin, FiX, FiBriefcase } from 'react-icons/fi';
 import { PiCertificateBold } from "react-icons/pi";
 import Home from './Home';
 import About from './About';
 import Education from './Education';
+import Experience from "./Experience";
 import Skills from './Skills';
 import Contact from './Contact';
 import Projects from './Projects';
@@ -25,10 +28,11 @@ const navItems = [
   { name: "Home", path: "/", icon: <FiHome size={18} /> },
   { name: "About", path: "/about", icon: <FiUser size={18} /> },
   { name: "Education", path: "/education", icon: <FiBook size={18} /> },
+  { name: "Experience", path: "/experience", icon: <FiBriefcase size={18} /> },
   { name: "Certifications", path: "/certifications", icon: <PiCertificateBold size={18} /> },
   { name: "Skills", path: "/skills", icon: <FiCode size={18} /> },
   { name: "Projects", path: "/projects", icon: <FiLayers size={18} /> },
-  { name: "Contact", path: "/contact", icon: <FiMail size={18} /> },
+  // { name: "Contact", path: "/contact", icon: <FiMail size={18} /> },
 ];
 
 const socialIcons = [
@@ -55,7 +59,7 @@ const AnimatedNavLink = ({ to, icon, name, darkMode, onClick }) => {
       {({ isActive }) => (
         <>
           <span className="mr-2 z-10">{icon}</span>
-          <span className="z-10">{name}</span>
+          <span className="z-10 md:text-sm lg:text-base">{name}</span>
           {isActive && (
             <motion.span
               layoutId="navIndicator"
@@ -125,34 +129,34 @@ export default function MainNavBar() {
         </div>
       </div>
 
-      {/* Glassmorphic Navbar */}
+      {/* Glassmorphic Navbar - Reduced for iPad */}
       <nav
         className={`fixed w-full z-40 transition-all duration-500 ${scrolled
-          ? 'py-2 backdrop-blur-xl shadow-[0_0_40px_rgba(56,189,248,0.25)]'
-          : 'py-4 backdrop-blur-lg shadow-[0_0_30px_rgba(168,85,247,0.2)]'
+          ? 'py-1 md:py-2 backdrop-blur-xl shadow-[0_0_40px_rgba(56,189,248,0.25)]'
+          : 'py-2 md:py-4 backdrop-blur-lg shadow-[0_0_30px_rgba(168,85,247,0.2)]'
           } ${darkMode
             ? 'bg-slate-950/80 border-b border-cyan-500/30'
             : 'bg-white/80 border-b border-cyan-400/40'
           }`}
       >
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-12">
-            {/* Logo/Brand */}
+        <div className="max-w-7xl mx-auto px-3 sm:px-4 md:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-10 md:h-12">
+            {/* Logo/Brand - Reduced for iPad */}
             <div className="flex-shrink-0 flex items-center">
               <div
-                className={`h-8 w-8 rounded-2xl flex items-center justify-center shadow-[0_0_18px_rgba(34,211,238,0.8)] border border-cyan-400/60 bg-slate-900`}
+                className={`h-6 w-6 md:h-8 md:w-8 rounded-xl md:rounded-2xl flex items-center justify-center shadow-[0_0_12px_rgba(34,211,238,0.8)] md:shadow-[0_0_18px_rgba(34,211,238,0.8)] border border-cyan-400/60 bg-slate-900`}
               >
                 <span className="text-white font-bold text-xs">DP</span>
               </div>
               <span
-                className={`ml-2 font-semibold text-lg bg-clip-text text-transparent bg-gradient-to-r from-cyan-300 via-sky-400 to-purple-400`}
+                className={`ml-1 md:ml-2 font-semibold text-sm md:text-lg bg-clip-text text-transparent bg-gradient-to-r from-cyan-300 via-sky-400 to-purple-400`}
               >
                 DevPortfolio
               </span>
             </div>
 
-            {/* Desktop Navigation */}
-            <div className="hidden md:flex items-center space-x-1">
+            {/* Desktop Navigation - Adjusted for iPad */}
+            <div className="hidden md:flex items-center space-x-0 lg:space-x-1">
               {navItems.map((item) => (
                 <AnimatedNavLink
                   key={item.name}
@@ -164,35 +168,35 @@ export default function MainNavBar() {
               ))}
             </div>
 
-            {/* Right side controls */}
-            <div className="flex items-center space-x-4">
+            {/* Right side controls - Adjusted for iPad */}
+            <div className="flex items-center space-x-2 md:space-x-3 lg:space-x-4">
               {/* Social icons */}
-              <div className="hidden md:flex items-center space-x-3">
+              <div className="hidden md:flex items-center space-x-2 lg:space-x-3">
                 {socialIcons.map((social, i) => (
                   <a
                     key={i}
                     href={social.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className={`p-2 rounded-full transition-all ${darkMode
+                    className={`p-1.5 md:p-2 rounded-full transition-all ${darkMode
                       ? 'text-gray-300 hover:text-white hover:bg-gray-800/50'
                       : 'text-gray-600 hover:text-gray-900 hover:bg-white/80'
                       }`}
                   >
-                    {social.icon}
+                    {React.cloneElement(social.icon, { size: 16 })}
                   </a>
                 ))}
 
                 {isDesktop && (
                   <button
                     onClick={toggleCursor}
-                    className={`p-2 rounded-full transition-all ${cursorEnabled
+                    className={`p-1.5 md:p-2 rounded-full transition-all ${cursorEnabled
                       ? "text-cyan-400 hover:bg-cyan-400/10"
                       : "text-gray-400 hover:bg-gray-400/10"
                       }`}
                     title="Toggle Custom Cursor"
                   >
-                    <FiMousePointer size={18} />
+                    <FiMousePointer size={16} />
                   </button>
                 )}
 
@@ -201,24 +205,24 @@ export default function MainNavBar() {
               {/* Theme toggle */}
               <button
                 onClick={toggleTheme}
-                className={`p-2 rounded-full transition-all ${darkMode
+                className={`p-1.5 md:p-2 rounded-full transition-all ${darkMode
                   ? 'text-yellow-300 hover:bg-gray-800/50'
                   : 'text-yellow-600 hover:bg-white/80'
                   }`}
               >
-                {darkMode ? <FiSun size={20} /> : <FiMoon size={20} />}
+                {darkMode ? <FiSun size={16} className="md:w-5 md:h-5" /> : <FiMoon size={16} className="md:w-5 md:h-5" />}
               </button>
 
               {/* Mobile menu button */}
               <button
                 onClick={toggleMobileMenu}
-                className="md:hidden p-2 rounded-md focus:outline-none"
+                className="md:hidden p-1.5 rounded-md focus:outline-none"
               >
                 {mobileMenuOpen ? (
-                  <FiX size={24} className={darkMode ? 'text-white' : 'text-gray-900'} />
+                  <FiX size={20} className={darkMode ? 'text-white' : 'text-gray-900'} />
                 ) : (
                   <svg
-                    className="h-6 w-6"
+                    className="h-5 w-5"
                     xmlns="http://www.w3.org/2000/svg"
                     fill="none"
                     viewBox="0 0 24 24"
@@ -241,7 +245,7 @@ export default function MainNavBar() {
         <div className={`md:hidden transition-all duration-300 ease-in-out overflow-hidden ${mobileMenuOpen ? 'max-h-screen opacity-100' : 'max-h-0 opacity-0'
           }`}
         >
-          <div className={`px-4 pt-2 pb-4 space-y-2 ${darkMode ? 'bg-gray-900/90' : 'bg-white/90'
+          <div className={`px-3 pt-1 pb-3 space-y-1 ${darkMode ? 'bg-gray-900/90' : 'bg-white/90'
             }`}
           >
             {navItems.map((item) => (
@@ -254,14 +258,14 @@ export default function MainNavBar() {
                 onClick={closeMobileMenu}
               />
             ))}
-            <div className="flex justify-center space-x-4 pt-4">
+            <div className="flex justify-center space-x-3 pt-3">
               {socialIcons.map((social, i) => (
                 <a
                   key={i}
                   href={social.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`p-3 rounded-full transition-all ${darkMode
+                  className={`p-2.5 rounded-full transition-all ${darkMode
                     ? 'text-gray-300 hover:text-white hover:bg-gray-800/50'
                     : 'text-gray-600 hover:text-gray-900 hover:bg-white/80'
                     }`}
@@ -274,9 +278,9 @@ export default function MainNavBar() {
         </div>
       </nav>
 
-      {/* Main Content with Page Transitions */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-28 pb-8">
-        <div className={`backdrop-blur-lg rounded-2xl overflow-hidden shadow-2xl transition-all duration-500 ${darkMode
+      {/* Main Content with Page Transitions - Adjusted for iPad */}
+      <main className="max-w-7xl mx-auto px-3 sm:px-4 md:px-6 lg:px-8 pt-20 md:pt-24 lg:pt-28 pb-6 md:pb-8">
+        <div className={`backdrop-blur-lg rounded-xl md:rounded-2xl overflow-hidden shadow-lg md:shadow-xl lg:shadow-2xl transition-all duration-500 ${darkMode
           ? 'bg-gray-900/30 border border-gray-700/30'
           : 'bg-white/30 border border-gray-200/30'
           }`}
@@ -311,6 +315,16 @@ export default function MainNavBar() {
                   transition={{ duration: 0.3 }}
                 >
                   <Education darkMode={darkMode} />
+                </motion.div>
+              } />
+              <Route path='/experience' element={
+                <motion.div
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  <Experience darkMode={darkMode} />
                 </motion.div>
               } />
               <Route path="/certifications" element={
@@ -358,7 +372,7 @@ export default function MainNavBar() {
         </div>
       </main>
 
-      <footer className={`relative py-6 transition-colors duration-500 backdrop-blur-xl overflow-hidden ${darkMode
+      <footer className={`relative py-4 md:py-6 transition-colors duration-500 backdrop-blur-xl overflow-hidden ${darkMode
         ? 'bg-slate-950/70 text-gray-300 border-t border-cyan-500/30 shadow-[0_-0_40px_rgba(56,189,248,0.25)]'
         : 'bg-white/70 text-gray-600 border-t border-cyan-400/40 shadow-[0_-0_30px_rgba(34,211,238,0.25)]'
         }`}>
@@ -366,19 +380,19 @@ export default function MainNavBar() {
         <div className="pointer-events-none absolute inset-0 -z-10">
           {darkMode ? (
             <>
-              <div className="absolute top-0 left-1/4 h-40 w-40 rounded-full bg-[radial-gradient(circle_at_center,#22d3ee_0,#22d3ee20_40%,transparent_70%)] blur-3xl" />
-              <div className="absolute top-0 right-1/4 h-40 w-40 rounded-full bg-[radial-gradient(circle_at_center,#a855f7_0,#a855f720_40%,transparent_70%)] blur-3xl" />
+              <div className="absolute top-0 left-1/4 h-32 md:h-40 w-32 md:w-40 rounded-full bg-[radial-gradient(circle_at_center,#22d3ee_0,#22d3ee20_40%,transparent_70%)] blur-2xl md:blur-3xl" />
+              <div className="absolute top-0 right-1/4 h-32 md:h-40 w-32 md:w-40 rounded-full bg-[radial-gradient(circle_at_center,#a855f7_0,#a855f720_40%,transparent_70%)] blur-2xl md:blur-3xl" />
             </>
           ) : (
             <>
-              <div className="absolute top-0 left-1/3 h-40 w-40 rounded-full bg-[radial-gradient(circle_at_center,#06b6d4_0,#06b6d420_40%,transparent_70%)] blur-3xl opacity-70" />
+              <div className="absolute top-0 left-1/3 h-32 md:h-40 w-32 md:w-40 rounded-full bg-[radial-gradient(circle_at_center,#06b6d4_0,#06b6d420_40%,transparent_70%)] blur-2xl md:blur-3xl opacity-70" />
             </>
           )}
         </div>
 
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto px-3 sm:px-4 md:px-6 lg:px-8">
           <div className="flex flex-col items-center justify-center">
-            <div className="text-sm text-center">
+            <div className="text-xs md:text-sm text-center">
               <p className="flex items-center justify-center">
                 Made with <BsFillHeartFill className="mx-1 text-red-500 animate-pulse" /> by Harsha using
                 <span className="relative mx-1 flex items-center justify-center">


### PR DESCRIPTION
Introduce a new Experience component (Internship detail page) built with framer-motion, react-icons, and theme-aware styles. Integrate it into MainNavBar: add a nav item and route for /experience, import the component, and comment out the Contact nav entry. Apply multiple responsive/ui adjustments to the navbar, header, main content and footer for better iPad/smaller-screen layout (reduced paddings, icon/button sizes, spacing, shadows, and border/radius tweaks), and normalize social icon sizing via React.cloneElement. Misc: add React import and small accessibility/formatting tweaks in MainNavBar.